### PR TITLE
Support for Super Monotonic Alignment Search

### DIFF
--- a/Configs/config.yaml
+++ b/Configs/config.yaml
@@ -9,7 +9,7 @@ epochs_2nd: 120 # number of peochs for second stage training
 batch_size: 1
 pretrained_model: "Outputs/LibriTTS/epoch_2nd_00119.pth"
 load_only_params: false 
-
+MAS_type: "legacy"
 
 train_data: "Data/train_list_libritts_20.txt"
 val_data: "Data/val_list_libritts.txt"

--- a/S_monotonic_align.py
+++ b/S_monotonic_align.py
@@ -1,0 +1,133 @@
+#- From https://github.com/supertone-inc/super-monotonic-align
+import torch
+
+
+@torch.no_grad()
+@torch.jit.script
+def maximum_path1(logp: torch.Tensor, attn_mask: torch.Tensor): # V1
+    # logp: [B, Tx, Ty], attn_mask: [B, Tx, Ty]
+    B, Tx, Ty = logp.size()
+    device = logp.device
+    logp = logp * attn_mask  # [B, Tx, Ty]
+    path = torch.zeros_like(logp)  # [B, Tx, Ty]
+    max_neg_val = torch.tensor(-1e32, dtype=logp.dtype, device=device)
+
+    x_len = attn_mask[:, :, 0].sum(dim=1).long()  # [B]
+    y_len = attn_mask[:, 0, :].sum(dim=1).long()  # [B]
+
+    for b in range(B):
+        path[b, x_len[b] - 1, y_len[b] - 1] = 1
+
+    # logp to cumulative logp
+    logp[:, 1:, 0] = max_neg_val
+
+    for ty in range(1, Ty):
+        logp_prev_frame_1 = logp[:, :, ty - 1]  # [B, Tx]
+        logp_prev_frame_2 = torch.roll(logp_prev_frame_1, shifts=1, dims=1)  # [B, Tx]
+        logp_prev_frame_2[:, 0] = max_neg_val
+        logp_prev_frame_max = torch.where(logp_prev_frame_1 > logp_prev_frame_2, logp_prev_frame_1, logp_prev_frame_2)
+        logp[:, :, ty] += logp_prev_frame_max
+
+    ids = torch.ones_like(x_len, device=device) * (x_len - 1)  # [B]
+    arange = torch.arange(B, device=device)
+    path = path.permute(2, 0, 1).contiguous()  # [Ty, B, Tx]
+    attn_mask = attn_mask.permute(2, 0, 1).contiguous()  # [Ty, B, Tx]
+    y_len_minus_1 = y_len - 1  # [B]
+    for ty in range(Ty - 1, 0, -1):
+        logp_prev_frame_1 = logp[:, :, ty - 1]  # [B, Tx]
+        logp_prev_frame_2 = torch.roll(logp_prev_frame_1, shifts=1, dims=1)  # [B, Tx]
+        logp_prev_frame_2[:, 0] = max_neg_val
+        direction = torch.where(logp_prev_frame_1 > logp_prev_frame_2, 0, -1)  # [B, Tx]
+        gathered_dir = torch.gather(direction, 1, ids.view(-1, 1)).view(-1)  # [B]
+        gathered_dir.masked_fill_(ty > y_len_minus_1, 0)
+        ids.add_(gathered_dir)
+        path[ty - 1, arange, ids] = 1
+    path *= attn_mask
+    path = path.permute(1, 2, 0)  # [B, Tx, Ty]
+    return path
+
+
+@torch.no_grad()
+def maximum_path2(logp: torch.Tensor, attn_mask: torch.Tensor): # V2
+    @torch.jit.script
+    def cumulative_logp(logp, attn_mask):
+        B, Tx, Ty = logp.size()
+        device = logp.device
+        logp = logp * attn_mask  # [B, Tx, Ty]
+        path = torch.zeros_like(logp)  # [B, Tx, Ty]
+        max_neg_val = torch.tensor(-1e32, dtype=logp.dtype, device=device)
+
+        x_len = attn_mask[:, :, 0].sum(dim=1).long()  # [B]
+        y_len = attn_mask[:, 0, :].sum(dim=1).long()  # [B]
+
+        for b in range(B):
+            path[b, x_len[b] - 1, y_len[b] - 1] = 1
+
+        # logp to cumulative logp
+        logp[:, 1:, 0] = max_neg_val
+
+        for ty in range(1, Ty):
+            logp_prev_frame_1 = logp[:, :, ty - 1]  # [B, Tx]
+            logp_prev_frame_2 = torch.roll(logp_prev_frame_1, shifts=1, dims=1)  # [B, Tx]
+            logp_prev_frame_2[:, 0] = max_neg_val
+            logp_prev_frame_max = torch.where(
+                logp_prev_frame_1 > logp_prev_frame_2, logp_prev_frame_1, logp_prev_frame_2
+            )
+            logp[:, :, ty] += logp_prev_frame_max
+        return logp, x_len, y_len, path
+
+    device = logp.device
+    logp, x_len, y_len, path = cumulative_logp(logp, attn_mask)
+    B, Tx, Ty = logp.size()
+    logp = logp.detach().cpu().numpy()
+    x_len = x_len.detach().cpu().numpy()
+    y_len = y_len.detach().cpu().numpy()
+    path = path.detach().cpu().numpy()
+    # backtracking (naive)
+    for b in range(B):
+        idx = x_len[b] - 1
+        path[b, x_len[b] - 1, y_len[b] - 1] = 1
+        for ty in range(y_len[b] - 1, 0, -1):
+            if idx != 0 and logp[b, idx - 1, ty - 1] > logp[b, idx, ty - 1]:
+                idx = idx - 1
+            path[b, idx, ty - 1] = 1
+    path = torch.from_numpy(path).to(device)
+    return path
+
+
+#- From https://github.com/resemble-ai/monotonic_align
+@torch.no_grad()
+def mask_from_len(lens: torch.Tensor, max_len=None):
+    """
+    Make a `mask` from sequence lengths.
+
+    Args:
+      inputs: (B, T, D)
+      lens: (B)
+
+    Returns
+      mask: (B, T)
+    """
+    if max_len is None:
+      max_len = lens.max()
+    index = torch.arange(max_len).to(lens).view(1, -1)
+    return index < lens.unsqueeze(1)  # (B, T)
+
+
+@torch.no_grad()
+def mask_from_lens(
+  similarity: torch.Tensor,
+  symbol_lens: torch.Tensor,
+  mel_lens: torch.Tensor,
+):
+  """
+  Args:
+    similarity: (B, S, T)
+    symbol_lens: (B,)
+    mel_lens: (B,)
+  """
+  _, S, T = similarity.size()
+  mask_S = mask_from_len(symbol_lens, S)
+  mask_T = mask_from_len(mel_lens, T)
+  mask_ST = mask_S.unsqueeze(2) * mask_T.unsqueeze(1)
+  return mask_ST.to(similarity)

--- a/S_monotonic_align_Triton.py
+++ b/S_monotonic_align_Triton.py
@@ -1,0 +1,109 @@
+#- From https://github.com/supertone-inc/super-monotonic-align
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def maximum_path_cp(
+        path, value, t_x, t_y,
+        B, T, S,
+        max_neg_val,
+        BLOCK_SIZE_X: tl.constexpr
+):
+    batch = tl.program_id(axis=0)
+    path += batch * T * S
+    value += batch * T * S
+    x_length = tl.load(t_x + batch)
+    y_length = tl.load(t_y + batch)
+    offs_prev = tl.arange(0, BLOCK_SIZE_X)
+    init = tl.where(offs_prev == 0, tl.load(value), max_neg_val)
+    # for j in range(0,1,1):  # set the first column to max_neg_val without init point
+    tl.store(value + offs_prev * S, init, mask=offs_prev < x_length)
+    for j in range(1, y_length, 1):
+        v_cur = tl.load(value + (offs_prev) * S + (j - 1), mask=(offs_prev < x_length), other=max_neg_val)
+        v_prev = tl.load(value + (offs_prev - 1) * S + (j - 1), mask=(0 < offs_prev) & (offs_prev < x_length),
+                         other=max_neg_val)
+        # compare v_cur and v_prev, and update v with larger value
+        v = (tl.maximum(v_cur, v_prev) + tl.load(value + (offs_prev) * S + j, mask=(offs_prev < x_length)))
+        tl.store(value + (offs_prev) * S + j, v, mask=(offs_prev < x_length))
+
+    index = x_length - 1
+    for j in range(y_length - 1, -1, -1):
+        tl.store(path + (index) * S + j, 1)
+        if (index > 0):  # (index == j) is not checked due to max_neg_val init
+            v_left = tl.load(value + (index) * S + j - 1)  # .to(tl.float32)
+            v_leftdown = tl.load(value + (index - 1) * S + j - 1)  # .to(tl.float32)
+            if (v_left < v_leftdown):
+                index += - 1
+
+
+@torch.no_grad()
+def maximum_path_triton(path, value, t_x, t_y, max_neg_val=-1e32):
+    B, T, S = path.shape
+    BLOCK_SIZE_X = max(triton.next_power_of_2(T), 16)
+    num_warps = 1  # Need to be 1 to prevent wrong output by slicing the operation
+    with torch.cuda.device(value.device.index):
+        maximum_path_cp[(B,)](
+            path, value, t_x, t_y,
+            B, T, S,
+            max_neg_val=max_neg_val,
+            num_warps=num_warps,
+            BLOCK_SIZE_X=BLOCK_SIZE_X)
+    return path
+
+
+@torch.no_grad()
+def maximum_path(value, mask, dtype=torch.float32): # callable
+    """ Triton optimized version.
+    value: [b, t_x, t_y]
+    mask: [b, t_x, t_y]
+    skip_mask: [b, t_x]
+    """
+    # check value is contiguous
+    value = value.contiguous()
+    # Use masked_fill_ to avoid new tensor creation
+    value = value.masked_fill_(mask.logical_not(), 0)
+    path = torch.zeros_like(value, dtype=dtype)
+    t_x_max = mask.sum(1)[:, 0].to(torch.int32)
+    t_y_max = mask.sum(2)[:, 0].to(torch.int32)
+    path = maximum_path_triton(path, value, t_x_max, t_y_max)
+    return path
+
+
+#- From https://github.com/resemble-ai/monotonic_align
+@torch.no_grad()
+def mask_from_len(lens: torch.Tensor, max_len=None):
+    """
+    Make a `mask` from sequence lengths.
+
+    Args:
+      inputs: (B, T, D)
+      lens: (B)
+
+    Returns
+      mask: (B, T)
+    """
+    if max_len is None:
+      max_len = lens.max()
+    index = torch.arange(max_len).to(lens).view(1, -1)
+    return index < lens.unsqueeze(1)  # (B, T)
+
+
+@torch.no_grad()
+def mask_from_lens(
+  similarity: torch.Tensor,
+  symbol_lens: torch.Tensor,
+  mel_lens: torch.Tensor,
+):
+  """
+  Args:
+    similarity: (B, S, T)
+    symbol_lens: (B,)
+    mel_lens: (B,)
+  """
+  _, S, T = similarity.size()
+  mask_S = mask_from_len(symbol_lens, S)
+  mask_T = mask_from_len(mel_lens, T)
+  mask_ST = mask_S.unsqueeze(2) * mask_T.unsqueeze(1)
+  return mask_ST.to(similarity)

--- a/train_first.py
+++ b/train_first.py
@@ -49,9 +49,12 @@ def main(config_path):
     config = yaml.safe_load(open(config_path))
     MAS_type = config['MAS_type']
     global maximum_path, mask_from_lens
-    if MAS_type == 'v1':  # Cython-free super-monotonic-align-v1 (https://github.com/supertone-inc/super-monotonic-align)
+    if MAS_type == 'v1' or MAS_type == 'v2':  # JIT based super-monotonic-align (https://github.com/supertone-inc/super-monotonic-align)
         import S_monotonic_align
-        maximum_path = S_monotonic_align.maximum_path1  # I/O : [batch_size=B, text_length=T, audio_length=S]
+        if MAS_type == 'v1':  # v1
+            maximum_path = S_monotonic_align.maximum_path1  # I/O : [batch_size=B, text_length=T, audio_length=S]
+        else: # v2
+            maximum_path = S_monotonic_align.maximum_path2  # same as above
         mask_from_lens = S_monotonic_align.mask_from_lens
     elif MAS_type == 'triton':  # super-monotonic-align-triton (needs triton)
         import S_monotonic_align_Triton

--- a/train_first.py
+++ b/train_first.py
@@ -19,8 +19,8 @@ from torch.utils.tensorboard import SummaryWriter
 
 from optimizers import build_optimizer
 from meldataset import build_dataloader
-from monotonic_align import maximum_path
-from monotonic_align import mask_from_lens
+#from monotonic_align import maximum_path
+#from monotonic_align import mask_from_lens
 from models import load_ASR_models, build_model, load_checkpoint
 from utils import get_data_path_list, length_to_mask, adv_loss, r1_reg, get_image, load_and_move_to_cuda
 
@@ -31,6 +31,7 @@ class MyDataParallel(torch.nn.DataParallel):
             return super().__getattr__(name)
         except AttributeError:
             return getattr(self.module, name)
+
 import logging
 from logging import StreamHandler
 
@@ -46,6 +47,21 @@ def main(config_path):
 
     train_step = "first"
     config = yaml.safe_load(open(config_path))
+    MAS_type = config['MAS_type']
+    global maximum_path, mask_from_lens
+    if MAS_type == 'v1':  # Cython-free super-monotonic-align-v1 (https://github.com/supertone-inc/super-monotonic-align)
+        import S_monotonic_align
+        maximum_path = S_monotonic_align.maximum_path1  # I/O : [batch_size=B, text_length=T, audio_length=S]
+        mask_from_lens = S_monotonic_align.mask_from_lens
+    elif MAS_type == 'triton':  # super-monotonic-align-triton (needs triton)
+        import S_monotonic_align_Triton
+        maximum_path = S_monotonic_align_Triton.maximum_path  # same as above
+        mask_from_lens = S_monotonic_align_Triton.mask_from_lens
+    elif MAS_type == 'legacy':  # the previous one (https://github.com/resemble-ai/monotonic_align)
+        import monotonic_align
+        maximum_path = monotonic_align.maximum_path  # I/O : [batch_size=B, symbol_len=S, mel_lens=T] (reversed symbols, but it is the same anyway)
+        mask_from_lens = monotonic_align.mask_from_lens
+
     log_dir = config['log_dir']
     if not osp.exists(log_dir): os.makedirs(log_dir, exist_ok=True)
     shutil.copy(config_path, osp.join(log_dir, osp.basename(config_path)))

--- a/train_second.py
+++ b/train_second.py
@@ -48,9 +48,12 @@ def main(config_path):
     config = yaml.safe_load(open(config_path))
     MAS_type = config['MAS_type']
     global maximum_path, mask_from_lens
-    if MAS_type == 'v1':  # Cython-free super-monotonic-align-v1 (https://github.com/supertone-inc/super-monotonic-align)
+    if MAS_type == 'v1' or MAS_type == 'v2':  # JIT based super-monotonic-align (https://github.com/supertone-inc/super-monotonic-align)
         import S_monotonic_align
-        maximum_path = S_monotonic_align.maximum_path1 # I/O : [batch_size=B, text_length=T, audio_length=S]
+        if MAS_type == 'v1':  # v1
+            maximum_path = S_monotonic_align.maximum_path1  # I/O : [batch_size=B, text_length=T, audio_length=S]
+        else:  # v2
+            maximum_path = S_monotonic_align.maximum_path2  # same as above
         mask_from_lens = S_monotonic_align.mask_from_lens
     elif MAS_type == 'triton':  # super-monotonic-align-triton (needs triton)
         import S_monotonic_align_Triton
@@ -58,7 +61,7 @@ def main(config_path):
         mask_from_lens = S_monotonic_align_Triton.mask_from_lens
     elif MAS_type == 'legacy':  # the previous one (https://github.com/resemble-ai/monotonic_align)
         import monotonic_align
-        maximum_path = monotonic_align.maximum_path # I/O : [batch_size=B, symbol_len=S, mel_lens=T] (reversed symbols, but it is the same anyway)
+        maximum_path = monotonic_align.maximum_path  # I/O : [batch_size=B, symbol_len=S, mel_lens=T] (reversed symbols, but it is the same anyway)
         mask_from_lens = monotonic_align.mask_from_lens
 
     log_dir = config['log_dir']

--- a/train_second.py
+++ b/train_second.py
@@ -19,8 +19,8 @@ from torch.utils.tensorboard import SummaryWriter
 from utils import *
 from optimizers import build_optimizer
 from meldataset import build_dataloader
-from monotonic_align import maximum_path
-from monotonic_align import mask_from_lens
+#from monotonic_align import maximum_path
+#from monotonic_align import mask_from_lens
 from models import load_ASR_models, build_model, load_checkpoint
 from Vocoder.vocoder import Generator
 
@@ -34,6 +34,7 @@ class MyDataParallel(torch.nn.DataParallel):
 
 import logging
 from logging import StreamHandler
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 handler = StreamHandler()
@@ -45,6 +46,20 @@ logger.addHandler(handler)
 def main(config_path):
 
     config = yaml.safe_load(open(config_path))
+    MAS_type = config['MAS_type']
+    global maximum_path, mask_from_lens
+    if MAS_type == 'v1':  # Cython-free super-monotonic-align-v1 (https://github.com/supertone-inc/super-monotonic-align)
+        import S_monotonic_align
+        maximum_path = S_monotonic_align.maximum_path1 # I/O : [batch_size=B, text_length=T, audio_length=S]
+        mask_from_lens = S_monotonic_align.mask_from_lens
+    elif MAS_type == 'triton':  # super-monotonic-align-triton (needs triton)
+        import S_monotonic_align_Triton
+        maximum_path = S_monotonic_align_Triton.maximum_path  # same as above
+        mask_from_lens = S_monotonic_align_Triton.mask_from_lens
+    elif MAS_type == 'legacy':  # the previous one (https://github.com/resemble-ai/monotonic_align)
+        import monotonic_align
+        maximum_path = monotonic_align.maximum_path # I/O : [batch_size=B, symbol_len=S, mel_lens=T] (reversed symbols, but it is the same anyway)
+        mask_from_lens = monotonic_align.mask_from_lens
 
     log_dir = config['log_dir']
     if not osp.exists(log_dir): os.makedirs(log_dir, exist_ok=True)

--- a/utils.py
+++ b/utils.py
@@ -4,22 +4,27 @@ import numpy as np
 import torch.nn.functional as F
 import matplotlib.pyplot as plt
 
-from monotonic_align.core import maximum_path_c
+try:
+    from monotonic_align.core import maximum_path_c
 
-def maximum_path(neg_cent, mask):
-  """ Cython optimized version.
-  neg_cent: [b, t_t, t_s]
-  mask: [b, t_t, t_s]
-  """
-  device = neg_cent.device
-  dtype = neg_cent.dtype
-  neg_cent =  np.ascontiguousarray(neg_cent.data.cpu().numpy().astype(np.float32))
-  path =  np.ascontiguousarray(np.zeros(neg_cent.shape, dtype=np.int32))
 
-  t_t_max = np.ascontiguousarray(mask.sum(1)[:, 0].data.cpu().numpy().astype(np.int32))
-  t_s_max = np.ascontiguousarray(mask.sum(2)[:, 0].data.cpu().numpy().astype(np.int32))
-  maximum_path_c(path, neg_cent, t_t_max, t_s_max)
-  return torch.from_numpy(path).to(device=device, dtype=dtype)
+    def maximum_path(neg_cent, mask):
+        """ Cython optimized version.
+        neg_cent: [b, t_t, t_s]
+        mask: [b, t_t, t_s]
+        """
+        device = neg_cent.device
+        dtype = neg_cent.dtype
+        neg_cent = np.ascontiguousarray(neg_cent.data.cpu().numpy().astype(np.float32))
+        path = np.ascontiguousarray(np.zeros(neg_cent.shape, dtype=np.int32))
+
+        t_t_max = np.ascontiguousarray(mask.sum(1)[:, 0].data.cpu().numpy().astype(np.int32))
+        t_s_max = np.ascontiguousarray(mask.sum(2)[:, 0].data.cpu().numpy().astype(np.int32))
+        maximum_path_c(path, neg_cent, t_t_max, t_s_max)
+        return torch.from_numpy(path).to(device=device, dtype=dtype)
+except:
+    pass
+
 
 def get_data_path_list(train_path=None, val_path=None):
     if train_path is None:


### PR DESCRIPTION
[Which is faster for large sized tensors(JIT) or faster overall(Triton)](https://github.com/supertone-inc/super-monotonic-align/tree/main?tab=readme-ov-file#benchmark), but most of all, we don't have to build monotonic alignment search. 
This can be accessed by changing `MAS_type: "legacy"`
 to `MAS_type: "v1"`, `MAS_type: "v2"` or `MAS_type: "triton"`(needs [triton](https://pypi.org/project/triton/)) in [./Configs/config.yaml](https://github.com/FENRlR/ArtSpeech/blob/S_MAS/Configs/config.yaml#L12C1-L12C19).

Original code from [supertone-inc/super-monotonic-align](https://github.com/supertone-inc/super-monotonic-align).

